### PR TITLE
Fixing the issue where tuber tyrants sometimes links to the goat isles game

### DIFF
--- a/css/sitestyle-dark.css
+++ b/css/sitestyle-dark.css
@@ -400,6 +400,7 @@ article#projects h4 {
 
 .project-entry.inactive {
   opacity: 0;
+  z-index: -10; /* Put the inactive project elements behind everything else, so we don't run into issues where you can't highlight the current project text or click the correct link 🤦🏾‍♀️ */
 }
 
 .project-screens {

--- a/css/sitestyle-dark.css
+++ b/css/sitestyle-dark.css
@@ -400,7 +400,9 @@ article#projects h4 {
 
 .project-entry.inactive {
   opacity: 0;
-  z-index: -10; /* Put the inactive project elements behind everything else, so we don't run into issues where you can't highlight the current project text or click the correct link 🤦🏾‍♀️ */
+  /* Put the inactive project elements behind everything else, so we don't run into 
+  issues where you can't highlight the current project text or click the correct link 🤦🏾‍♀️ */
+  z-index: -10; 
 }
 
 .project-screens {


### PR DESCRIPTION
I decided to just do a quick (somewhat hacky) fix by setting the CSS value of `z-index` to a negative number. This tells the page to move that element "behind" all the ones (at least at long as it's marked with the `inactive` class). Worked locally; will try it out on the netlify preview.